### PR TITLE
Version and changelog update on pull requests fails

### DIFF
--- a/.github/workflows/gource.yml
+++ b/.github/workflows/gource.yml
@@ -2,7 +2,7 @@ name: Gource
 on:
   push:
     branches:
-      - '**'
+      - 'develop'
 
 jobs:
   action:

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -9,11 +9,15 @@ jobs:
     outputs:
       labelNames: $${{ steps.add_labels.outputs.labelNames }}
     steps:
-      - name: the fyck is githubs variables?
-        run: |
-          echo 'Job context is ${{ toJSON(github) }}'
-      
+      - name: Is there a issue linked in "development"?
+        id: validator
+        uses: HarshCasper/validate-issues-over-pull-requests@v0.1.1
+        with:
+          prbody: ${{ github.event.pull_request.body }}
+          prurl: ${{ github.event.pull_request.url }}
+          
       - name: Find linked issues
+        if: ${{ steps.validator.outputs.valid == 1 }}
         id: links
         uses: hossainemruz/linked-issues@main
         with:
@@ -21,6 +25,7 @@ jobs:
           format: IssueNumber
       
       - name: Add labels of associated/linked issue to the pull request
+        if: ${{ steps.validator.outputs.valid == 1 }}
         id: add_labels
         run: |
           for issueNumber in ${{ steps.links.outputs.issues }}

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -101,7 +101,7 @@ jobs:
       
       - name: Add comment to pull request
         run: |
-          commentList=gh api -H "Accept: application/vnd.github+json" /repos/${{github.repository}}/issues/${{github.event.number}}/comments
+          commentList=`gh api -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments`
           echo "commentList="$commentList
           exit 1
           

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -2,6 +2,8 @@ name: Version and changelog update
 on:
   pull_request:
     types: [ opened, edited, synchronize, closed ]
+env: # Global environment variables
+  NEXT_VERSION: # will be defined in the job
 jobs:
   find-linked-issues-and-copy-labels-to-pull-request:
     name: Copy labels from issue to pull request
@@ -161,6 +163,8 @@ jobs:
           
       - name: Check environment
         run: |
+          echo "jobs.update-version.env.next_version="${{ jobs.update-version.env.next_version }}
+          echo "jobs.update-version.env.NEXT_VERSION="${{ jobs.update-version.env.NEXT_VERSION }}
           echo "NEXT_VERSION="$NEXT_VERSION
           echo "env.NEXT_VERSION="${{ env.NEXT_VERSION }}
           echo "env.next_version=""${{ env.next_version }}"

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -162,6 +162,7 @@ jobs:
           fetch-depth: 0
       
       - name: Generate CHANGELOG.md, when merged
+        id: generate_changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -172,7 +173,7 @@ jobs:
       
       - name: Commit and push CHANGELOG.md, when merged
         env:
-          CHANGELOG: ${{ needs.update-changelog.outputs.changelog }}
+          CHANGELOG: ${{ steps.generate_changelog.outputs.changelog }}
           MERGED: ${{ github.event.pull_request.merged }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           nextVersion="v$NEXT_VERSION+$(git log --oneline | wc -l)"
           echo "nextVersion="$nextVersion
-          echo "NEXT_VERSION=$nextVersion" >> $GITHUB_ENV
+          echo "NEXT_VERSION=${nextVersion}" >> $GITHUB_ENV
           echo "::set-output name=futureRelease::${nextVersion}"
       
       - name: Add comment to pull request
@@ -211,7 +211,7 @@ jobs:
           output: "CHANGELOG.md"
           issueLineLabels: "ALL"
           breakingLabels: "backwards-incompatible,breaking,rework,refactor"
-          futureRelease: ${{ env.FUTURE_RELEASE }}
+          futureRelease: $FUTURE_RELEASE
       
       - name: Commit and push CHANGELOG.md, when merged
         env:

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -120,11 +120,11 @@ jobs:
             fi
           done
           
-          body="When this pull request was merged:\r\n- Current Version **$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}**\r\n- Tag **$NEXT_VERSION** will be created to the specific commit."
+          bodybody="When this pull request was merged:\n- Current Version **$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}**\n- Tag **$NEXT_VERSION** will be created to the specific commit."
           statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
           echo "statusCode="$statusCode
           
-          if [[ $statusCode == *""* ]]
+          if [[ $statusCode == "" ]]
           then
             echo "Unable to add comment to pull request!"
             exit 1
@@ -176,6 +176,24 @@ jobs:
           CHANGELOG: ${{ needs.update-changelog.outputs.changelog }}
           MERGED: ${{ github.event.pull_request.merged }}
         run: |
+        
+          bodybody="When this pull request was merged, then:\n$CHANGELOG"
+
+          statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
+
+          echo "statusCode="$statusCode
+
+          
+
+          if [[ $statusCode == "" ]]
+
+          then
+
+            echo "Unable to add comment to pull request!"
+
+            exit 1
+
+          fi
           if [ $MERGED == true ]
           then
             git fetch

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -52,10 +52,6 @@ jobs:
           done
           echo "labelNames="$labelNames
           data="{\"labels\":[${labelNames}]}"
-  
-          commentList=gh api -H "Accept: application/vnd.github+json" /repos/${{github.repository}}/issues/${{github.event.number}}/comments
-          echo "commentList="$commentList
-          exit 1
           
           curlResponse=`curl --write-out '%{http_code}' --output /dev/null --request POST \
           --header 'Accept: application/vnd.github.v3+json' \
@@ -105,6 +101,12 @@ jobs:
       
       - name: Add comment to pull request
         run: |
+          commentList=gh api -H "Accept: application/vnd.github+json" /repos/${{github.repository}}/issues/${{github.event.number}}/comments
+          echo "commentList="$commentList
+          exit 1
+          
+          
+          
           body="{\"body\":\"When this pull request was merged\\\:\r\n- Version will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}**\r\n- Tag **$NEXT_VERSION** will be created to the specific commit.\"}"
         
           curlResponse=`curl --write-out '%{http_code}' --output /dev/null --request POST \

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -17,9 +17,8 @@ jobs:
         with:
           prbody: ${{ github.event.pull_request.body }}
           prurl: ${{ github.event.pull_request.url }}
-  
-      - name: PR has no valid Issue
-        if: ${{ steps.validator.outputs.valid == 0 }}
+      
+      - name: "'Development' set?"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRNUM: ${{ github.event.pull_request.number }}
@@ -29,28 +28,31 @@ jobs:
           # https://jqplay.org/s/WsuVZ8f-YiB
           commentIds=$(echo $commentListResponse | jq '.[] | select(.body | contains("PR is not linked to any issue")) | .id')
           echo "commentIds="$commentIds
-  
+        
           for commentId in $commentIds
           do
             echo "commentId="$commentId
             statusCode=`gh api --method DELETE -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/comments/$commentId`
             echo "statusCode="$statusCode
-            if [[ $statusCode == "" ]]
+            if [[ $statusCode != "" ]]
             then
               echo "Unable to delete comment with id "$commentId
             fi
           done
-  
-          body="PR is not linked to any issue, please make the corresponding changes in the body by adding 'Fixes #issue-number' or 'Resolves #issue-number'. If your PR isn't linked to any issue, ignore this comment!"
-          statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
-          echo "statusCode="$statusCode
-  
-          if [[ $statusCode == "" ]]
+
+          if [ ${{ steps.validator.outputs.valid }} == 0 ]
           then
-            echo "Unable to add comment to pull request!"
-            exit 1
+            body="PR is not linked to any issue, please make the corresponding changes in the body by adding 'Fixes #issue-number' or 'Resolves #issue-number'. If your PR isn't linked to any issue, ignore this comment!"
+            statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
+            echo "statusCode="$statusCode
+          
+            if [[ $statusCode == "" ]]
+            then
+              echo "Unable to add comment to pull request!"
+              exit 1
+            fi
           fi
-  
+      
       - name: Find linked issues
         if: ${{ steps.validator.outputs.valid == 1 }}
         id: links
@@ -77,7 +79,7 @@ jobs:
           done
           echo "labelNames="$labelNames
           data="{\"labels\":[${labelNames}]}"
-          
+        
           curlResponse=`curl --write-out '%{http_code}' --output /dev/null --request POST \
           --header 'Accept: application/vnd.github.v3+json' \
           --header 'Authorization: token ${{ github.token }}' \
@@ -139,28 +141,28 @@ jobs:
           # https://jqplay.org/s/WsuVZ8f-YiB
           commentIds=$(echo $commentListResponse | jq '.[] | select(.body | contains("will be automatically increase to")) | .id')
           echo "commentIds="$commentIds
-  
+        
           for commentId in $commentIds
           do
             echo "commentId="$commentId
             statusCode=`gh api --method DELETE -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/comments/$commentId`
             echo "statusCode="$statusCode
-            if [[ $statusCode == "" ]]
+            if [[ $statusCode != "" ]]
             then
               echo "Unable to delete comment with id "$commentId
             fi
           done
-          
+        
           body="When this pull request was merged: <br /> - Current Version **v$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}** <br /> - Tag **$NEXT_VERSION** will be created to the specific commit."
           statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
           echo "statusCode="$statusCode
-          
+        
           if [[ $statusCode == "" ]]
           then
             echo "Unable to add comment to pull request!"
             exit 1
           fi
-  
+      
       - name: Commit and push version changes and tag it, when merged
         env:
           MERGED: ${{ github.event.pull_request.merged }}
@@ -191,7 +193,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          
+      
       - name: Check environment
         run: |
           echo "needs.update-version.env.next_version="${{ needs.update-version.env.next_version }}
@@ -224,32 +226,32 @@ jobs:
           # https://jqplay.org/s/WsuVZ8f-YiB
           commentIds=$(echo $commentListResponse | jq '.[] | select(.body | contains("# Changelog")) | .id')
           echo "commentIds="$commentIds
-  
+        
           for commentId in $commentIds
           do
             echo "commentId="$commentId
             statusCode=`gh api --method DELETE -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/comments/$commentId`
             echo "statusCode="$statusCode
-            if [[ $statusCode == "" ]]
+            if [[ $statusCode != "" ]]
             then
               echo "Unable to delete comment with id "$commentId
             fi
           done
-          
+        
           echo ""
           echo "CHANGELOG="$CHANGELOG
           echo ""
-  
+        
           printf -v escapedChangelog "%q\n" $CHANGELOG
           echo "escapedChangelog="$escapedChangelog
-          
+        
           statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$CHANGELOG"`
           echo "statusCode="$statusCode
           if [[ $statusCode == "" ]]
           then
             echo "Unable to add comment to pull request!"
           fi
-          
+        
           if [ $MERGED == true ]
           then
             git fetch

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -161,7 +161,7 @@ jobs:
         with:
           fetch-depth: 0
       
-      - name: Generate CHANGELOG.md, when merged
+      - name: Generate CHANGELOG.md
         id: generate_changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3
         with:
@@ -170,6 +170,7 @@ jobs:
           output: "CHANGELOG.md"
           issueLineLabels: "ALL"
           breakingLabels: "backwards-incompatible,breaking,rework,refactor"
+          futureRelease: $NEXT_VERSION
       
       - name: Commit and push CHANGELOG.md, when merged
         env:

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -93,7 +93,7 @@ jobs:
             exit 1
           fi
         
-          echo "::set-output name=labelNames::{labelNames}"
+          echo "::set-output name=labelNames::"$labelNames
   
   update-version:
     needs: find-linked-issues-and-copy-labels-to-pull-request
@@ -128,7 +128,7 @@ jobs:
           nextVersion="v$NEXT_VERSION+$(git log --oneline | wc -l)"
           echo "nextVersion="$nextVersion
           echo "NEXT_VERSION=${nextVersion}" >> $GITHUB_ENV
-          echo "::set-output name=futureRelease::{nextVersion}"
+          echo "::set-output name=futureRelease::"$nextVersion}
       
       - name: Add comment to pull request
         env:

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -120,7 +120,7 @@ jobs:
             fi
           done
           
-          body="When this pull request was merged:  \n- Current Version **$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}**  \n- Tag **$NEXT_VERSION** will be created to the specific commit."
+          body="When this pull request was merged:[space][space][enter] - Current Version **$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}**  \n - Tag **$NEXT_VERSION** will be created to the specific commit."
           statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
           echo "statusCode="$statusCode
           

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -24,7 +24,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRNUM: ${{ github.event.pull_request.number }}
         run: |
-          gh pr comment $PRNUM --body "PR is not linked to any issue, please make the corresponding changes in the body by adding 'Fixes #issue-number' or 'Resolves #issue-number'. If your PR isn't linked to any issue, ignore this comment!"
+          commentListResponse=`gh api -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments`
+          echo "commentListResponse="$commentListResponse
+          # https://jqplay.org/s/WsuVZ8f-YiB
+          commentIds=$(echo $commentListResponse | jq '.[] | select(.body | contains("PR is not linked to any issue")) | .id')
+          echo "commentIds="$commentIds
+  
+          for commentId in $commentIds
+          do
+            echo "commentId="$commentId
+            statusCode=`gh api --method DELETE -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/comments/$commentId`
+            echo "statusCode="$statusCode
+            if [[ $statusCode == "" ]]
+            then
+              echo "Unable to delete comment with id "$commentId
+            fi
+          done
+  
+          body="PR is not linked to any issue, please make the corresponding changes in the body by adding 'Fixes #issue-number' or 'Resolves #issue-number'. If your PR isn't linked to any issue, ignore this comment!"
+          statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
+          echo "statusCode="$statusCode
+  
+          if [[ $statusCode == "" ]]
+          then
+            echo "Unable to add comment to pull request!"
+            exit 1
+          fi
   
       - name: Find linked issues
         if: ${{ steps.validator.outputs.valid == 1 }}

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -170,7 +170,7 @@ jobs:
           output: "CHANGELOG.md"
           issueLineLabels: "ALL"
           breakingLabels: "backwards-incompatible,breaking,rework,refactor"
-          futureRelease: $NEXT_VERSION
+          futureRelease: ${{ env.NEXT_VERSION }}
       
       - name: Commit and push CHANGELOG.md, when merged
         env:
@@ -181,7 +181,7 @@ jobs:
           commentListResponse=`gh api -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments`
           echo "commentListResponse="$commentListResponse
           # https://jqplay.org/s/WsuVZ8f-YiB
-          commentIds=$(echo $commentListResponse | jq '.[] | select(.body | contains("CHANGELOG.md will be changed to")) | .id')
+          commentIds=$(echo $commentListResponse | jq '.[] | select(.body | contains("# Changelog ## [")) | .id')
           echo "commentIds="$commentIds
   
           for commentId in $commentIds
@@ -202,7 +202,6 @@ jobs:
           printf -v escapedChangelog "%q\n" $CHANGELOG
           echo "escapedChangelog="$escapedChangelog
           
-          body='When this pull request was merged, CHANGELOG.md will be changed to: <br /> "$CHANGELOG"'
           statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$CHANGELOG"`
           echo "statusCode="$statusCode
           if [[ $statusCode == "" ]]

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -120,7 +120,7 @@ jobs:
             fi
           done
           
-          body="When this pull request was merged: \ - Current Version **$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}** \ - Tag **$NEXT_VERSION** will be created to the specific commit."
+          body="When this pull request was merged: <br /> - Current Version **$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}** <br /> - Tag **$NEXT_VERSION** will be created to the specific commit."
           statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
           echo "statusCode="$statusCode
           
@@ -194,8 +194,8 @@ jobs:
             fi
           done
           
-          body="When this pull request was merged, CHANGELOG.md will be changed to: \ "$CHANGELOG
-          statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
+          body='When this pull request was merged, CHANGELOG.md will be changed to: <br /> "$CHANGELOG"'
+          statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$CHANGELOG"`
           echo "statusCode="$statusCode
           if [[ $statusCode == "" ]]
           then

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -26,8 +26,6 @@ jobs:
         run: |
           gh pr comment $PRNUM --body "PR is not linked to any issue, please make the corresponding changes in the body by adding 'Fixes #issue-number' or 'Resolves #issue-number'. If your PR isn't linked to any issue, ignore this comment!"
   
-
-
       - name: Find linked issues
         if: ${{ steps.validator.outputs.valid == 1 }}
         id: links
@@ -54,7 +52,11 @@ jobs:
           done
           echo "labelNames="$labelNames
           data="{\"labels\":[${labelNames}]}"
-        
+  
+          commentList=gh api -H "Accept: application/vnd.github+json" /repos/${{github.repository}}/issues/${{github.event.number}}/comments
+          echo "commentList="$commentList
+          exit 1
+          
           curlResponse=`curl --write-out '%{http_code}' --output /dev/null --request POST \
           --header 'Accept: application/vnd.github.v3+json' \
           --header 'Authorization: token ${{ github.token }}' \

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -106,7 +106,7 @@ jobs:
           commentList=`gh api -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments`
           echo "commentList="$commentList
           # https://jqplay.org/s/WsuVZ8f-YiB
-          commentIds=jq '.[] | select(.body | contains("Version will be automatically increase to")) | .id'
+          commentIds=`jq '.[] | select(.body | contains("Version will be automatically increase to")) | .id'`
           echo "commentIds="$commentIds
   
           for commentId in $commentIds do

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -15,6 +15,24 @@ jobs:
         with:
           prbody: ${{ github.event.pull_request.body }}
           prurl: ${{ github.event.pull_request.url }}
+  
+      - name: PR has no valid Issue
+        if: ${{ steps.validator.outputs.valid == 0 }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRNUM: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment $PRNUM --body "PR is not linked to any issue, please make the corresponding changes in the body by adding 'Fixes #issue-number' or 'Resolves #issue-number'. If your PR isn't linked to any issue, ignore this comment!"
+          gh pr edit $PRNUM --add-label "PR:No-Issue"
+  
+      - name: PR has a valid Issue
+        if: ${{ steps.validator.outputs.valid == 1 }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRNUM: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit $PRNUM --add-label "PR:Ready-to-Review"
+          gh pr edit $PRNUM --remove-label "PR:No-Issue"
           
       - name: Find linked issues
         if: ${{ steps.validator.outputs.valid == 1 }}

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -121,7 +121,7 @@ jobs:
           done
           
           body="{\"body\":\"When this pull request was merged\\\:\r\n- Current Version **$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}**\r\n- Tag **$NEXT_VERSION** will be created to the specific commit.\"}"
-          statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body=$body`
+          statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
           echo "statusCode="$statusCode
           
           if [[ $statusCode != *"201"* ]]

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -120,13 +120,13 @@ jobs:
             fi
           done
           
-          body="{\"body\":\"When this pull request was merged\\\:\r\n- Current Version **$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}**\r\n- Tag **$NEXT_VERSION** will be created to the specific commit.\"}"
+          body="When this pull request was merged:\r\n- Current Version **$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}**\r\n- Tag **$NEXT_VERSION** will be created to the specific commit."
           statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
           echo "statusCode="$statusCode
           
-          if [[ $statusCode != *"201"* ]]
+          if [[ $statusCode == *""* ]]
           then
-            echo "Unable to add comment to pull request"
+            echo "Unable to add comment to pull request!"
             exit 1
           fi
   

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -120,7 +120,7 @@ jobs:
             fi
           done
           
-          body="When this pull request was merged:[space][space][enter] - Current Version **$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}**  \n - Tag **$NEXT_VERSION** will be created to the specific commit."
+          body="When this pull request was merged: \ - Current Version **$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}** \ - Tag **$NEXT_VERSION** will be created to the specific commit."
           statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
           echo "statusCode="$statusCode
           
@@ -194,7 +194,7 @@ jobs:
             fi
           done
           
-          body="When this pull request was merged, CHANGELOG.md will be changed to:  \n$CHANGELOG"
+          body="When this pull request was merged, CHANGELOG.md will be changed to: \ "$CHANGELOG
           statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
           echo "statusCode="$statusCode
           if [[ $statusCode == "" ]]

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -175,6 +175,7 @@ jobs:
         env:
           CHANGELOG: ${{ needs.update-changelog.outputs.changelog }}
           MERGED: ${{ github.event.pull_request.merged }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           commentListResponse=`gh api -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments`
           echo "commentListResponse="$commentListResponse

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -25,17 +25,9 @@ jobs:
           PRNUM: ${{ github.event.pull_request.number }}
         run: |
           gh pr comment $PRNUM --body "PR is not linked to any issue, please make the corresponding changes in the body by adding 'Fixes #issue-number' or 'Resolves #issue-number'. If your PR isn't linked to any issue, ignore this comment!"
-          gh pr edit $PRNUM --add-label "PR:No-Issue"
   
-      - name: PR has a valid Issue
-        if: ${{ steps.validator.outputs.valid == 1 }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PRNUM: ${{ github.event.pull_request.number }}
-        run: |
-          gh pr edit $PRNUM --add-label "PR:Ready-to-Review"
-          gh pr edit $PRNUM --remove-label "PR:No-Issue"
-          
+
+
       - name: Find linked issues
         if: ${{ steps.validator.outputs.valid == 1 }}
         id: links

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -77,6 +77,8 @@ jobs:
       VERSION_FILE_NAME: 'mods/noita-mp/.version'
       VERSION_FRAGMENT: 'will be fetched by file'
     name: Increase version and create a tag, when merged
+    outputs:
+      labelNames: $${{ steps.extend_version.outputs.futureRelease }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -96,8 +98,10 @@ jobs:
           next-version-put-build-metadata: true
       
       - name: Extend version with custom build numbers
+        id: extend_version
         run: |
           nextVersion="v$NEXT_VERSION+$(git log --oneline | wc -l)"
+          echo "nextVersion="$nextVersion
           echo "NEXT_VERSION=$nextVersion" >> $GITHUB_ENV
           echo "::set-output name=futureRelease::${nextVersion}"
       

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -26,7 +26,7 @@ jobs:
           commentListResponse=`gh api -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments`
           echo "commentListResponse="$commentListResponse
           # https://jqplay.org/s/WsuVZ8f-YiB
-          commentIds=$(echo $commentListResponse | jq '.[] | select(.body | contains("PR is not linked to any issue")) | .id')
+          commentIds=$(echo $commentListResponse | jq '.[] | select(.body | contains("your pull request is not linked to any issue")) | .id')
           echo "commentIds="$commentIds
         
           for commentId in $commentIds
@@ -42,7 +42,7 @@ jobs:
 
           if [ ${{ steps.validator.outputs.valid }} == 0 ]
           then
-            body="PR is not linked to any issue, please make the corresponding changes in the body by adding 'Fixes #issue-number' or 'Resolves #issue-number'. If your PR isn't linked to any issue, ignore this comment!"
+            body=":warning: @${{ github.event.issue.user.login }}, your pull request is not linked to any issue, please make the corresponding changes in the very first comments body by adding 'Fixes #issue-number' or 'Resolves #issue-number'. If your pull request isn't linked to any issue, ignore this comment!"
             statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
             echo "statusCode="$statusCode
           

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -162,7 +162,6 @@ jobs:
           fetch-depth: 0
       
       - name: Generate CHANGELOG.md, when merged
-        if: ${{ github.event.pull_request.merged }}
         uses: heinrichreimer/github-changelog-generator-action@v2.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -104,18 +104,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           commentListResponse=`gh api -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments`
-          echo "commentListResponse="commentListResponse
+          echo "commentListResponse="$commentListResponse
           # https://jqplay.org/s/WsuVZ8f-YiB
           commentIds=$(echo $commentListResponse | jq '.[] | select(.body | contains("Version will be automatically increase to")) | .id')
           echo "commentIds="$commentIds
   
-          for commentId in $commentIds do
+          for commentId in $commentIds
+          do
             echo "commentId="$commentId
             statusCode=`gh api --method DELETE -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments/$commentId`
             echo "statusCode="$statusCode
             if [[ $statusCode != *"204"* ]]
             then
-              echo "Unable to delete comment with id $commentId"
+              echo "Unable to delete comment with id "$commentId
             fi
           done
           

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -93,7 +93,7 @@ jobs:
             exit 1
           fi
         
-          echo "::set-output name=labelNames::"$labelNames
+          echo "::set-output name=labelNames::$labelNames"
   
   update-version:
     needs: find-linked-issues-and-copy-labels-to-pull-request
@@ -128,7 +128,7 @@ jobs:
           nextVersion="v$NEXT_VERSION+$(git log --oneline | wc -l)"
           echo "nextVersion="$nextVersion
           echo "NEXT_VERSION=${nextVersion}" >> $GITHUB_ENV
-          echo "::set-output name=futureRelease::"$nextVersion}
+          echo "::set-output name=futureRelease::$nextVersion"
       
       - name: Add comment to pull request
         env:
@@ -151,7 +151,7 @@ jobs:
             fi
           done
           
-          body="When this pull request was merged: <br /> - Current Version **$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}** <br /> - Tag **$NEXT_VERSION** will be created to the specific commit."
+          body="When this pull request was merged: <br /> - Current Version v**$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}** <br /> - Tag **$NEXT_VERSION** will be created to the specific commit."
           statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
           echo "statusCode="$statusCode
           
@@ -211,7 +211,7 @@ jobs:
           output: "CHANGELOG.md"
           issueLineLabels: "ALL"
           breakingLabels: "backwards-incompatible,breaking,rework,refactor"
-          futureRelease: ${{ env.FUTURE_RELEASE }}
+          futureRelease: ${{ needs.update-version.outputs.futureRelease }}
       
       - name: Commit and push CHANGELOG.md, when merged
         env:

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -120,7 +120,7 @@ jobs:
             fi
           done
           
-          body="When this pull request was merged:\n- Current Version **$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}**\n- Tag **$NEXT_VERSION** will be created to the specific commit."
+          body="When this pull request was merged:  \n- Current Version **$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}**  \n- Tag **$NEXT_VERSION** will be created to the specific commit."
           statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
           echo "statusCode="$statusCode
           
@@ -194,7 +194,7 @@ jobs:
             fi
           done
           
-          body="When this pull request was merged, CHANGELOG.md will be changed to:\n$CHANGELOG"
+          body="When this pull request was merged, CHANGELOG.md will be changed to:  \n$CHANGELOG"
           statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
           echo "statusCode="$statusCode
           if [[ $statusCode == "" ]]

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -2,6 +2,8 @@ name: Version and changelog update
 on:
   pull_request:
     types: [ opened, edited, synchronize, closed ]
+env: # global environment variables
+  NEXT_VERSION: 'will be set by the workflow'
 jobs:
   find-linked-issues-and-copy-labels-to-pull-request:
     name: Copy labels from issue to pull request
@@ -152,9 +154,7 @@ jobs:
   
   update-changelog:
     needs: update-version
-    env:
-      VERSION_FILE_NAME: 'mods/noita-mp/.version'
-    name: Update CHANGELOG.md, when merged
+    name: Update CHANGELOG.md
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -2,8 +2,6 @@ name: Version and changelog update
 on:
   pull_request:
     types: [ opened, edited, synchronize, closed ]
-env: # global environment variables
-  NEXT_VERSION: 'will be set by the workflow'
 jobs:
   find-linked-issues-and-copy-labels-to-pull-request:
     name: Copy labels from issue to pull request
@@ -164,7 +162,8 @@ jobs:
       - name: Check environment
         run: |
           echo "NEXT_VERSION="$NEXT_VERSION
-          echo ${{ env.NEXT_VERSION }}
+          echo "env.NEXT_VERSION="${{ env.NEXT_VERSION }}
+          echo "env.next_version=""${{ env.next_version }}"
       
       - name: Generate CHANGELOG.md
         id: generate_changelog
@@ -186,7 +185,7 @@ jobs:
           commentListResponse=`gh api -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments`
           echo "commentListResponse="$commentListResponse
           # https://jqplay.org/s/WsuVZ8f-YiB
-          commentIds=$(echo $commentListResponse | jq '.[] | select(.body | contains("# Changelog ## [")) | .id')
+          commentIds=$(echo $commentListResponse | jq '.[] | select(.body | contains("# Changelog")) | .id')
           echo "commentIds="$commentIds
   
           for commentId in $commentIds

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -163,8 +163,8 @@ jobs:
           
       - name: Check environment
         run: |
-          echo "update-version.env.next_version="${{ update-version.env.next_version }}
-          echo "update-version.env.NEXT_VERSION="${{ update-version.env.NEXT_VERSION }}
+          echo "needs.update-version.env.next_version="${{ needs.update-version.env.next_version }}
+          echo "needs.update-version.env.NEXT_VERSION="${{ needs.update-version.env.NEXT_VERSION }}
           echo "NEXT_VERSION="$NEXT_VERSION
           echo "env.NEXT_VERSION="${{ env.NEXT_VERSION }}
           echo "env.next_version=""${{ env.next_version }}"

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -26,7 +26,7 @@ jobs:
           commentListResponse=`gh api -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments`
           echo "commentListResponse="$commentListResponse
           # https://jqplay.org/s/WsuVZ8f-YiB
-          commentIds=$(echo $commentListResponse | jq '.[] | select(.body | contains("your pull request is not linked to any issue")) | .id')
+          commentIds=$(echo $commentListResponse | jq '.[] | select(.body | contains("Your pull request is not linked to any issue")) | .id')
           echo "commentIds="$commentIds
         
           for commentId in $commentIds
@@ -42,7 +42,7 @@ jobs:
 
           if [ ${{ steps.validator.outputs.valid }} == 0 ]
           then
-            body=":warning: @${{ github.event.issue.user.login }}, your pull request is not linked to any issue, please make the corresponding changes in the very first comments body by adding 'Fixes #issue-number' or 'Resolves #issue-number'. If your pull request isn't linked to any issue, ignore this comment!"
+            body=":warning: :exclamation: Your pull request is not linked to any issue, please make the corresponding changes in the very first comments body by adding 'Fixes #issue-number' or 'Resolves #issue-number'. If your pull request isn't linked to any issue, ignore this comment!"
             statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
             echo "statusCode="$statusCode
           

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -93,7 +93,7 @@ jobs:
             exit 1
           fi
         
-          echo "::set-output name=labelNames::$labelNames"
+          echo "::set-output name=labelNames::labelNames"
   
   update-version:
     needs: find-linked-issues-and-copy-labels-to-pull-request
@@ -128,7 +128,7 @@ jobs:
           nextVersion="v$NEXT_VERSION+$(git log --oneline | wc -l)"
           echo "nextVersion="$nextVersion
           echo "NEXT_VERSION=${nextVersion}" >> $GITHUB_ENV
-          echo "::set-output name=futureRelease::$nextVersion"
+          echo "::set-output name=futureRelease::nextVersion"
       
       - name: Add comment to pull request
         env:
@@ -151,7 +151,7 @@ jobs:
             fi
           done
           
-          body="When this pull request was merged: <br /> - Current Version v**$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}** <br /> - Tag **$NEXT_VERSION** will be created to the specific commit."
+          body="When this pull request was merged: <br /> - Current Version **v$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}** <br /> - Tag **$NEXT_VERSION** will be created to the specific commit."
           statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
           echo "statusCode="$statusCode
           
@@ -211,7 +211,7 @@ jobs:
           output: "CHANGELOG.md"
           issueLineLabels: "ALL"
           breakingLabels: "backwards-incompatible,breaking,rework,refactor"
-          futureRelease: ${{ needs.update-version.outputs.futureRelease }}
+          futureRelease: ${{ env.FUTURE_RELEASE }}
       
       - name: Commit and push CHANGELOG.md, when merged
         env:

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -93,7 +93,7 @@ jobs:
             exit 1
           fi
         
-          echo "::set-output name=labelNames::${labelNames}"
+          echo "::set-output name=labelNames::{labelNames}"
   
   update-version:
     needs: find-linked-issues-and-copy-labels-to-pull-request
@@ -128,7 +128,7 @@ jobs:
           nextVersion="v$NEXT_VERSION+$(git log --oneline | wc -l)"
           echo "nextVersion="$nextVersion
           echo "NEXT_VERSION=${nextVersion}" >> $GITHUB_ENV
-          echo "::set-output name=futureRelease::${nextVersion}"
+          echo "::set-output name=futureRelease::{nextVersion}"
       
       - name: Add comment to pull request
         env:

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -106,7 +106,7 @@ jobs:
           commentList=`gh api -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments`
           echo "commentList="$commentList
           # https://jqplay.org/s/WsuVZ8f-YiB
-          commentIds=jq -e '.[] | select(.body | contains("Version will be automatically increase to")) | .id'
+          commentIds=jq '.[] | select(.body | contains("Version will be automatically increase to")) | .id'
           echo "commentIds="$commentIds
   
           for commentId in $commentIds do

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -106,13 +106,13 @@ jobs:
           commentListResponse=`gh api -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments`
           echo "commentListResponse="$commentListResponse
           # https://jqplay.org/s/WsuVZ8f-YiB
-          commentIds=$(echo $commentListResponse | jq '.[] | select(.body | contains("Version will be automatically increase to")) | .id')
+          commentIds=$(echo $commentListResponse | jq '.[] | select(.body | contains("will be automatically increase to")) | .id')
           echo "commentIds="$commentIds
   
           for commentId in $commentIds
           do
             echo "commentId="$commentId
-            statusCode=`gh api --method DELETE -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments/$commentId`
+            statusCode=`gh api --method DELETE -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/comments/$commentId`
             echo "statusCode="$statusCode
             if [[ $statusCode != *"204"* ]]
             then
@@ -120,7 +120,7 @@ jobs:
             fi
           done
           
-          body="{\"body\":\"When this pull request was merged\\\:\r\n- Version will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}**\r\n- Tag **$NEXT_VERSION** will be created to the specific commit.\"}"
+          body="{\"body\":\"When this pull request was merged\\\:\r\n- Current Version **$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}**\r\n- Tag **$NEXT_VERSION** will be created to the specific commit.\"}"
           statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body=$body`
           echo "statusCode="$statusCode
           

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -2,8 +2,6 @@ name: Version and changelog update
 on:
   pull_request:
     types: [ opened, edited, synchronize, closed ]
-env: # Global environment variables
-  NEXT_VERSION: # will be defined in the job
 jobs:
   find-linked-issues-and-copy-labels-to-pull-request:
     name: Copy labels from issue to pull request
@@ -99,7 +97,9 @@ jobs:
       
       - name: Extend version with custom build numbers
         run: |
-          echo "NEXT_VERSION=v$NEXT_VERSION+$(git log --oneline | wc -l)" >> $GITHUB_ENV
+          nextVersion="v$NEXT_VERSION+$(git log --oneline | wc -l)"
+          echo "NEXT_VERSION=$nextVersion" >> $GITHUB_ENV
+          echo "::set-output name=futureRelease::${nextVersion}"
       
       - name: Add comment to pull request
         env:
@@ -154,6 +154,8 @@ jobs:
   
   update-changelog:
     needs: update-version
+    env:
+      FUTURE_RELEASE: ${{ needs.update-version.outputs.futureRelease }}
     name: Update CHANGELOG.md
     runs-on: ubuntu-latest
     steps:
@@ -168,6 +170,8 @@ jobs:
           echo "NEXT_VERSION="$NEXT_VERSION
           echo "env.NEXT_VERSION="${{ env.NEXT_VERSION }}
           echo "env.next_version=""${{ env.next_version }}"
+          echo "FUTURE_RELEASE="$FUTURE_RELEASE
+          echo "env.FUTURE_RELEASE="${{ env.FUTURE_RELEASE }}
       
       - name: Generate CHANGELOG.md
         id: generate_changelog
@@ -178,7 +182,7 @@ jobs:
           output: "CHANGELOG.md"
           issueLineLabels: "ALL"
           breakingLabels: "backwards-incompatible,breaking,rework,refactor"
-          futureRelease: ${{ env.NEXT_VERSION }}
+          futureRelease: ${{ env.FUTURE_RELEASE }}
       
       - name: Commit and push CHANGELOG.md, when merged
         env:

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -194,6 +194,13 @@ jobs:
             fi
           done
           
+          echo ""
+          echo "CHANGELOG="$CHANGELOG
+          echo ""
+  
+          printf -v escapedChangelog "%q\n" $CHANGELOG
+          echo "escapedChangelog="$escapedChangelog
+          
           body='When this pull request was merged, CHANGELOG.md will be changed to: <br /> "$CHANGELOG"'
           statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$CHANGELOG"`
           echo "statusCode="$statusCode

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -103,13 +103,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          commentList=`gh api -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments`
-          echo "commentList="$commentList
+          commentListResponse=`gh api -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments`
+          echo "commentListResponse="commentListResponse
           # https://jqplay.org/s/WsuVZ8f-YiB
-          commentIds=`jq '.[] | select(.body | contains("Version will be automatically increase to")) | .id'`
+          commentIds=$(echo $commentListResponse | jq '.[] | select(.body | contains("Version will be automatically increase to")) | .id')
           echo "commentIds="$commentIds
   
           for commentId in $commentIds do
+            echo "commentId="$commentId
             statusCode=`gh api --method DELETE -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments/$commentId`
             echo "statusCode="$statusCode
             if [[ $statusCode != *"204"* ]]

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -160,6 +160,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          
+      - name: Check environment
+        run: |
+          echo "NEXT_VERSION="$NEXT_VERSION
+          echo ${{ env.NEXT_VERSION }}
       
       - name: Generate CHANGELOG.md
         id: generate_changelog

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -78,7 +78,7 @@ jobs:
       VERSION_FRAGMENT: 'will be fetched by file'
     name: Increase version and create a tag, when merged
     outputs:
-      labelNames: $${{ steps.extend_version.outputs.futureRelease }}
+      futureRelease: $${{ steps.extend_version.outputs.futureRelease }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -114,13 +114,13 @@ jobs:
             echo "commentId="$commentId
             statusCode=`gh api --method DELETE -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/comments/$commentId`
             echo "statusCode="$statusCode
-            if [[ $statusCode != *"204"* ]]
+            if [[ $statusCode == "" ]]
             then
               echo "Unable to delete comment with id "$commentId
             fi
           done
           
-          bodybody="When this pull request was merged:\n- Current Version **$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}**\n- Tag **$NEXT_VERSION** will be created to the specific commit."
+          body="When this pull request was merged:\n- Current Version **$CURRENT_VERSION** will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}**\n- Tag **$NEXT_VERSION** will be created to the specific commit."
           statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
           echo "statusCode="$statusCode
           
@@ -176,24 +176,31 @@ jobs:
           CHANGELOG: ${{ needs.update-changelog.outputs.changelog }}
           MERGED: ${{ github.event.pull_request.merged }}
         run: |
-        
-          bodybody="When this pull request was merged, then:\n$CHANGELOG"
-
-          statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
-
-          echo "statusCode="$statusCode
-
+          commentListResponse=`gh api -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments`
+          echo "commentListResponse="$commentListResponse
+          # https://jqplay.org/s/WsuVZ8f-YiB
+          commentIds=$(echo $commentListResponse | jq '.[] | select(.body | contains("CHANGELOG.md will be changed to")) | .id')
+          echo "commentIds="$commentIds
+  
+          for commentId in $commentIds
+          do
+            echo "commentId="$commentId
+            statusCode=`gh api --method DELETE -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/comments/$commentId`
+            echo "statusCode="$statusCode
+            if [[ $statusCode == "" ]]
+            then
+              echo "Unable to delete comment with id "$commentId
+            fi
+          done
           
-
+          body="When this pull request was merged, CHANGELOG.md will be changed to:\n$CHANGELOG"
+          statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body="$body"`
+          echo "statusCode="$statusCode
           if [[ $statusCode == "" ]]
-
           then
-
             echo "Unable to add comment to pull request!"
-
-            exit 1
-
           fi
+          
           if [ $MERGED == true ]
           then
             git fetch
@@ -207,4 +214,3 @@ jobs:
           else
             echo "Pull request is not merged yet, therefore CHANGELOG.md will not be updated."
           fi
-      

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -105,23 +105,26 @@ jobs:
         run: |
           commentList=`gh api -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments`
           echo "commentList="$commentList
-          exit 1
-          
-          
+          # https://jqplay.org/s/WsuVZ8f-YiB
+          commentIds=jq -e '.[] | select(.body | contains("Version will be automatically increase to")) | .id'
+          echo "commentIds="$commentIds
+  
+          for commentId in $commentIds do
+            statusCode=`gh api --method DELETE -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments/$commentId`
+            echo "statusCode="$statusCode
+            if [[ $statusCode != *"204"* ]]
+            then
+              echo "Unable to delete comment with id $commentId"
+            fi
+          done
           
           body="{\"body\":\"When this pull request was merged\\\:\r\n- Version will be automatically increase to **$NEXT_VERSION** in **${{ github.base_ref }}**\r\n- Tag **$NEXT_VERSION** will be created to the specific commit.\"}"
-        
-          curlResponse=`curl --write-out '%{http_code}' --output /dev/null --request POST \
-          --header 'Accept: application/vnd.github+json' \
-          --header 'Authorization: token ${{ github.token }}' \
-          --url 'https://api.github.com/repos/${{github.repository}}/issues/${{github.event.number}}/comments' \
-          --data-raw "$body"`
-        
-          if [[ $curlResponse == *"201"* ]]
+          statusCode=`gh api --method POST -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments -f body=$body`
+          echo "statusCode="$statusCode
+          
+          if [[ $statusCode != *"201"* ]]
           then
-            echo "SUCCESS"
-          else
-            echo "FAILURE"
+            echo "Unable to add comment to pull request"
             exit 1
           fi
   

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -9,6 +9,10 @@ jobs:
     outputs:
       labelNames: $${{ steps.add_labels.outputs.labelNames }}
     steps:
+      - name: the fyck is githubs variables?
+        run: |
+          echo 'Job context is ${{ toJSON(github) }}'
+      
       - name: Find linked issues
         id: links
         uses: hossainemruz/linked-issues@main

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -9,6 +9,8 @@ jobs:
     outputs:
       labelNames: $${{ steps.add_labels.outputs.labelNames }}
     steps:
+      - uses: actions/checkout@v3
+      
       - name: Is there a issue linked in "development"?
         id: validator
         uses: HarshCasper/validate-issues-over-pull-requests@v0.1.1

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -7,7 +7,7 @@ jobs:
     name: Copy labels from issue to pull request
     runs-on: ubuntu-latest
     outputs:
-      labelNames: $${{ steps.add_labels.outputs.labelNames }}
+      labelNames: ${{ steps.add_labels.outputs.labelNames }}
     steps:
       - uses: actions/checkout@v3
       
@@ -93,7 +93,7 @@ jobs:
             exit 1
           fi
         
-          echo "::set-output name=labelNames::labelNames"
+          echo "::set-output name=labelNames::$labelNames"
   
   update-version:
     needs: find-linked-issues-and-copy-labels-to-pull-request
@@ -103,7 +103,7 @@ jobs:
       VERSION_FRAGMENT: 'will be fetched by file'
     name: Increase version and create a tag, when merged
     outputs:
-      futureRelease: $${{ steps.extend_version.outputs.futureRelease }}
+      futureRelease: ${{ steps.extend_version.outputs.futureRelease }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -128,7 +128,7 @@ jobs:
           nextVersion="v$NEXT_VERSION+$(git log --oneline | wc -l)"
           echo "nextVersion="$nextVersion
           echo "NEXT_VERSION=${nextVersion}" >> $GITHUB_ENV
-          echo "::set-output name=futureRelease::nextVersion"
+          echo "::set-output name=futureRelease::$nextVersion"
       
       - name: Add comment to pull request
         env:

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -100,6 +100,8 @@ jobs:
           echo "NEXT_VERSION=v$NEXT_VERSION+$(git log --oneline | wc -l)" >> $GITHUB_ENV
       
       - name: Add comment to pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           commentList=`gh api -H 'Accept: application/vnd.github+json' /repos/${{github.repository}}/issues/${{github.event.number}}/comments`
           echo "commentList="$commentList

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -211,7 +211,7 @@ jobs:
           output: "CHANGELOG.md"
           issueLineLabels: "ALL"
           breakingLabels: "backwards-incompatible,breaking,rework,refactor"
-          futureRelease: $FUTURE_RELEASE
+          futureRelease: ${{ env.FUTURE_RELEASE }}
       
       - name: Commit and push CHANGELOG.md, when merged
         env:

--- a/.github/workflows/version-and-changelog-update.yml
+++ b/.github/workflows/version-and-changelog-update.yml
@@ -163,8 +163,8 @@ jobs:
           
       - name: Check environment
         run: |
-          echo "jobs.update-version.env.next_version="${{ jobs.update-version.env.next_version }}
-          echo "jobs.update-version.env.NEXT_VERSION="${{ jobs.update-version.env.NEXT_VERSION }}
+          echo "update-version.env.next_version="${{ update-version.env.next_version }}
+          echo "update-version.env.NEXT_VERSION="${{ update-version.env.NEXT_VERSION }}
           echo "NEXT_VERSION="$NEXT_VERSION
           echo "env.NEXT_VERSION="${{ env.NEXT_VERSION }}
           echo "env.next_version=""${{ env.next_version }}"


### PR DESCRIPTION
When there is a pull request without any other branch or issue linked, the version and changelog update action will fail, because no associated branch or issue was found, whereby the whole action workflow will fail, but when there isn't any branch or issue linked, this specific workflow should be skipped and only the build/commit number should be increased.

Fixes #78 